### PR TITLE
Fix pollution scaling issues with Krastorio2 & modded biters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Ide files
+.vscode

--- a/constants.lua
+++ b/constants.lua
@@ -8,6 +8,7 @@ firePollutionScale = 2*(1+(f-1)/2)
 coalPollutionScale = 6*f --was 4*f before 0.18
 miningPollutionScale = 5*f --was 2*f before 0.18
 pollutionSpawnIncrease = 1.75/20 --/60, then /15, then /5 from 0.17's pollution redesign, then /4 again in 0.18
+pollutionToJoinAttackScale = 660/4 -- Divided by vanilla small biter pollution requirement
 treePollutionAbsorptionScale = 15*f --was 10 in 0.16, the change in 0.17 broke it (tick -> second name change), and the new values did not yet take it into account
 
 maxBoreholeSize = 500 --this is number of cycles, not fluid capacity

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -207,3 +207,8 @@ for name,fluid in pairs(data.raw.fluid) do
 		)
 	end
 end
+
+-- Scale biter attack pollution
+for k,obj in pairs(data.raw["unit"]) do
+	obj.pollution_to_join_attack = obj.pollution_to_join_attack*pollutionToJoinAttackScale
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -20,7 +20,6 @@ end
 data.raw.recipe["firearm-magazine"].ingredients = {{"iron-plate", 3}} -- go from 4 plates to 1.5 plates each
 data.raw.recipe["firearm-magazine"].result_count = 2 --since attacks are going to be VERY frequent and early game resources are at a premium; since this ammo is obsoleted rapidly, does not affect mid to late game
 
-data.raw.unit["small-biter"].pollution_to_join_attack = 660 --was 200, then 400, then 500
 data.raw.unit["small-biter"].max_health = 12 --was 15
 data.raw.unit["small-biter"].attack_parameters.ammo_type = make_unit_melee_ammo_type(6) --was 7
 

--- a/info.json
+++ b/info.json
@@ -4,7 +4,13 @@
   "title": "Nauvis Day",
   "author": "Reika",
   "homepage": "",
-  "factorio_version" : "1.1",
-  "dependencies": ["base", "DragonIndustries", "? bobplates", "? bobassembly"],
+  "factorio_version": "1.1",
+  "dependencies": [
+    "base",
+    "DragonIndustries",
+    "? bobplates",
+    "? bobassembly",
+    "? Krastorio2"
+  ],
   "description": "Pollution is much more of a problem than before, but you do have increased flexibility with it."
 }

--- a/info.json
+++ b/info.json
@@ -10,7 +10,8 @@
     "DragonIndustries",
     "? bobplates",
     "? bobassembly",
-    "? Krastorio2"
+    "? Krastorio2",
+    "? Rampant"
   ],
   "description": "Pollution is much more of a problem than before, but you do have increased flexibility with it."
 }


### PR DESCRIPTION
Not sure if this is a significant enough change to make a PR, but

There are issues with Nauvis Day & Krastorio2 (specifically the space exploration compatibility scripts, as this doesn't happen when space exploration isn't installed) that cause the pollution values of some things (mining drills, boilers) to not be scaled. Adding Krastorio2 as an optional dependency makes Nauvis Day run after Krastorio, which fixes the issue.